### PR TITLE
Refactor error handling and update version to 0.1.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ description = "zhipuai 's api of rust"
 documentation = "https://docs.rs/zhipuai-rs"
 repository  = "https://github.com/AnlangA/zhipuai-rs.git"
 license = "MIT"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 
 [[example]]

--- a/examples/chat/chat.rs
+++ b/examples/chat/chat.rs
@@ -1,10 +1,8 @@
-use anyhow::Result;
 use std::io::{self, Write};
-use zhipuai_rs::chat_simple_message;
-use zhipuai_rs::prelude::*;
+use zhipuai_rs::{chat_simple_message, prelude::*};
 
 #[tokio::main]
-async fn main() -> Result<(), Error> {
+async fn main() -> anyhow::Result<()> {
     let api_key = user_key().unwrap();
 
     let mut messages = Messages::new()
@@ -49,7 +47,7 @@ async fn main() -> Result<(), Error> {
 }
 
 // 用于从终端读取用户输入的函数
-fn user_key() -> Result<String> {
+fn user_key() -> anyhow::Result<String> {
     let mut input = String::new();
     print!("输入你的key: ");
     io::stdout().flush()?; // 刷新标准输出，确保提示文字立即显示

--- a/examples/chat/chat_codegeex.rs
+++ b/examples/chat/chat_codegeex.rs
@@ -1,9 +1,8 @@
-use anyhow::Result;
 use std::io::{self, Write};
 use zhipuai_rs::prelude::*;
 
 #[tokio::main]
-async fn main() -> Result<(), Error> {
+async fn main() -> anyhow::Result<()> {
     let api_key = user_key().unwrap();
     let (api_url, request_json) = BigModel::<Chat>::new(ChatModelName::CodeGeeX.into())
         .add_code_context(Extra::new(Target::new(
@@ -33,7 +32,7 @@ async fn main() -> Result<(), Error> {
     Ok(())
 }
 
-fn user_key() -> Result<String> {
+fn user_key() -> anyhow::Result<String> {
     let mut input = String::new();
     print!("输入你的key: ");
     io::stdout().flush()?; // 刷新标准输出，确保提示文字立即显示

--- a/examples/chat/chat_draw.rs
+++ b/examples/chat/chat_draw.rs
@@ -1,17 +1,18 @@
-use anyhow::Result;
 use std::io::{self, Write};
 use zhipuai_rs::prelude::*;
 
 #[tokio::main]
-async fn main() -> Result<(), Error> {
+async fn main() -> anyhow::Result<()> {
     let api_key = user_key().unwrap();
     let tool = DrawingTool;
     let (api_url, request_json) = BigModel::<Chat>::new(ChatModelName::GLM4Alltools.into())
-        .add_message(
-            Message::new(Role::User.into(), 
-            Some(Context::rich_contexts(RichContent::text("生成一个 hello kitty 的Melody风格 壁纸"))),
-            None)
-        )
+        .add_message(Message::new(
+            Role::User.into(),
+            Some(Context::rich_contexts(RichContent::text(
+                "生成一个 hello kitty 的Melody风格 壁纸",
+            ))),
+            None,
+        ))
         .add_tools(Tool::new().drawing_tool(tool))
         .stream_enable(true)
         .build();
@@ -33,7 +34,7 @@ async fn main() -> Result<(), Error> {
     Ok(())
 }
 
-fn user_key() -> Result<String> {
+fn user_key() -> anyhow::Result<String> {
     let mut input = String::new();
     print!("输入你的key: ");
     io::stdout().flush()?; // 刷新标准输出，确保提示文字立即显示

--- a/examples/chat/chat_function.rs
+++ b/examples/chat/chat_function.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use std::{
     collections::HashMap,
     io::{self, Write},
@@ -6,7 +5,7 @@ use std::{
 use zhipuai_rs::prelude::*;
 
 #[tokio::main]
-async fn main() -> Result<(), Error> {
+async fn main() -> anyhow::Result<()> {
     let api_key = user_key().unwrap();
     let mut hash = HashMap::new();
     hash.insert(
@@ -58,7 +57,7 @@ async fn main() -> Result<(), Error> {
     Ok(())
 }
 
-fn user_key() -> Result<String> {
+fn user_key() -> anyhow::Result<String> {
     let mut input = String::new();
     print!("输入你的key: ");
     io::stdout().flush()?; // 刷新标准输出，确保提示文字立即显示

--- a/examples/chat/chat_image.rs
+++ b/examples/chat/chat_image.rs
@@ -1,11 +1,10 @@
-use anyhow::Result;
 use base64::prelude::*;
 use std::io::{self, Write};
 use tokio::{fs::File, io::AsyncReadExt};
 use zhipuai_rs::prelude::*;
 
 #[tokio::main]
-async fn main() -> Result<(), Error> {
+async fn main() -> anyhow::Result<()> {
     let api_key = user_key().unwrap();
     let mut data = Default::default();
     File::open("examples/assets/video_frame.jpg")
@@ -47,7 +46,7 @@ async fn main() -> Result<(), Error> {
     Ok(())
 }
 
-fn user_key() -> Result<String> {
+fn user_key() -> anyhow::Result<String> {
     let mut input = String::new();
     print!("输入你的key: ");
     io::stdout().flush()?; // 刷新标准输出，确保提示文字立即显示

--- a/examples/chat/chat_stream.rs
+++ b/examples/chat/chat_stream.rs
@@ -1,9 +1,8 @@
-use anyhow::Result;
 use std::io::{self, Write};
 use zhipuai_rs::prelude::*;
 
 #[tokio::main]
-async fn main() -> Result<(), Error> {
+async fn main() -> anyhow::Result<()> {
     let api_key = user_key().unwrap();
     let (api_url, request_json) = BigModel::<Chat>::new(ChatModelName::GLMZeroPreview.into())
         .add_message(Message::new(
@@ -39,7 +38,7 @@ async fn main() -> Result<(), Error> {
     Ok(())
 }
 
-fn user_key() -> Result<String> {
+fn user_key() -> anyhow::Result<String> {
     let mut input = String::new();
     print!("输入你的key: ");
     io::stdout().flush()?; // 刷新标准输出，确保提示文字立即显示

--- a/examples/chat/chat_web_search.rs
+++ b/examples/chat/chat_web_search.rs
@@ -1,9 +1,8 @@
-use anyhow::Result;
 use std::io::{self, Write};
 use zhipuai_rs::prelude::*;
 
 #[tokio::main]
-async fn main() -> Result<(), Error> {
+async fn main() -> anyhow::Result<()> {
     let api_key = user_key().unwrap();
     let prompt = "
 
@@ -63,7 +62,7 @@ async fn main() -> Result<(), Error> {
     Ok(())
 }
 
-fn user_key() -> Result<String> {
+fn user_key() -> anyhow::Result<String> {
     let mut input = String::new();
     print!("输入你的key: ");
     io::stdout().flush()?; // 刷新标准输出，确保提示文字立即显示

--- a/examples/rtav.rs
+++ b/examples/rtav.rs
@@ -9,7 +9,7 @@ use tokio::{fs::File, io::AsyncReadExt};
 use zhipuai_rs::prelude::*;
 
 #[tokio::main]
-async fn main() -> anyhow::Result<(), RealtimeSessionError> {
+async fn main() -> anyhow::Result<()> {
     let api_key = user_key().unwrap();
     let (mut sink, mut stream) = start_realtime_session(&api_key).await?;
     sink.session_update(

--- a/src/api_resource/rtav.rs
+++ b/src/api_resource/rtav.rs
@@ -2,12 +2,10 @@
 //! GLM-Realtime API 能够提供实时的视频通话功能，具有跨文本、音频和视频进行实时推理的能力，AI可以进行流畅的通话，人可以实时打断AI。
 //! 除了实时音频交互外，Realtime还可通过手机或AIPC的摄像头与人互动，通过共享电脑屏幕阅读页面信息，通过视频流理解对话当前的环境。
 
-mod error;
 mod event;
 mod value;
 
-pub use error::*;
-pub use event::*;
+use crate::error::ZhipuApiError;
 use futures::{
     stream::{SplitSink, SplitStream},
     Sink, SinkExt, Stream, StreamExt,
@@ -23,7 +21,7 @@ use tokio_tungstenite::{
     tungstenite::{client::IntoClientRequest, http::StatusCode, Message},
     MaybeTlsStream, WebSocketStream,
 };
-pub use value::*;
+pub use {event::*, value::*};
 
 #[pin_project]
 pub struct SessionSink {
@@ -38,7 +36,7 @@ impl SessionSink {
     ///
     /// # 参数
     /// * `session`: 会话配置。
-    pub async fn session_update(&mut self, session: &Session) -> Result<(), SessionError> {
+    pub async fn session_update(&mut self, session: &Session) -> Result<(), ZhipuApiError> {
         self.send(Event::new_session_update(session)?).await
     }
 
@@ -50,7 +48,7 @@ impl SessionSink {
     /// * `audio`: 仅支持wav格式，默认采样率为16000；
     /// 如需自定义采样率，可在参数中标注，wav48表示48000hz采样率；
     /// 建议使用16000、24000、48000hz；
-    pub async fn input_audio_buffer_append(&mut self, audio: &[u8]) -> Result<(), SessionError> {
+    pub async fn input_audio_buffer_append(&mut self, audio: &[u8]) -> Result<(), ZhipuApiError> {
         self.send(Event::new_input_audio_buffer_append(audio)?)
             .await
     }
@@ -62,7 +60,7 @@ impl SessionSink {
     pub async fn input_audio_buffer_append_video_frame(
         &mut self,
         video_frame: &[u8],
-    ) -> Result<(), SessionError> {
+    ) -> Result<(), ZhipuApiError> {
         self.send(Event::new_input_audio_buffer_append_video_frame(
             video_frame,
         )?)
@@ -71,7 +69,7 @@ impl SessionSink {
 
     /// 提交已经上传的音频文件，此事件前必须进行 input_audio_buffer.append，且必须上传一个有效音频或视频文件，否则提交事件会报错。ServerVAD模式下不需要发送此事件，模型将自动上传并提交音频
     /// 调用 input_audio_buffer.commit 时，如果缓冲区内发过 video_frame，会一起打包提交调用模型推理。
-    pub async fn input_audio_buffer_commit(&mut self) -> Result<(), SessionError> {
+    pub async fn input_audio_buffer_commit(&mut self) -> Result<(), ZhipuApiError> {
         self.send(Event::new_input_audio_buffer_commit()?).await
     }
 
@@ -82,24 +80,24 @@ impl SessionSink {
     pub async fn conversation_item_create(
         &mut self,
         item: &ConversationItem,
-    ) -> Result<(), SessionError> {
+    ) -> Result<(), ZhipuApiError> {
         self.send(Event::new_conversation_item_create(item)?).await
     }
 
     /// 此事件为创建服务器响应，同时也表示触发模型推理。ServerVAD模式服务器会自动创建响应，ClientVAD模式进行视频通话时，需以这个时间点的视频帧和音频传给模型；
     /// 当chat_mode为video时，提交事件之前必须通过input_audio_buffer.append_video_frame事件上传至少一张图片，否则无法创建模型回复，会返回错误事件video_model_query_error；
-    pub async fn response_create(&mut self) -> Result<(), SessionError> {
+    pub async fn response_create(&mut self) -> Result<(), ZhipuApiError> {
         self.send(Event::new_response_create()?).await
     }
 
     /// 取消模型调用
-    pub async fn response_cancel(&mut self) -> Result<(), SessionError> {
+    pub async fn response_cancel(&mut self) -> Result<(), ZhipuApiError> {
         self.send(Event::new_response_cancel()?).await
     }
 }
 
 impl Sink<Event> for SessionSink {
-    type Error = SessionError;
+    type Error = ZhipuApiError;
 
     fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Pin::new(&mut self.project().inner)
@@ -133,7 +131,7 @@ pub struct SessionStream {
 
 impl SessionStream {
     /// 获取下一个事件数据
-    pub async fn next_data(&mut self) -> Result<Option<EventData>, SessionError> {
+    pub async fn next_data(&mut self) -> Result<Option<EventData>, ZhipuApiError> {
         self.next()
             .await
             .map_or_else(|| Ok(None), |e| e.map_or_else(Err, |e| e.data().map(Some)))
@@ -141,7 +139,7 @@ impl SessionStream {
 }
 
 impl Stream for SessionStream {
-    type Item = Result<Event, SessionError>;
+    type Item = Result<Event, ZhipuApiError>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         Pin::new(&mut self.project().inner)
@@ -166,7 +164,7 @@ const URL: &str = "wss://open.bigmodel.cn/api/paas/v4/realtime";
 
 pub async fn start_realtime_session(
     api_key: &str,
-) -> Result<(SessionSink, SessionStream), SessionError> {
+) -> Result<(SessionSink, SessionStream), ZhipuApiError> {
     let mut req = URL.into_client_request()?;
     req.headers_mut()
         .insert("Authorization", format!("Bearer {}", api_key).parse()?);
@@ -177,7 +175,7 @@ pub async fn start_realtime_session(
     // 这通常是HTTP升级响应
     let status = response.status();
     if StatusCode::SWITCHING_PROTOCOLS != status && !status.is_success() {
-        return Err(SessionError::StatusCode(status.to_string()));
+        return Err(ZhipuApiError::StatusCode(status.to_string()));
     }
 
     let (send, recv) = stream.split();

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
-use super::Error as RealtimeError;
+use crate::api_resource::rtav::Error as RealtimeError;
 use base64::DecodeError;
-use reqwest::header::InvalidHeaderValue;
+use reqwest::{header::InvalidHeaderValue, Error as ReqwestError};
 use serde_json::Error as JsonError;
 use std::{
     error::Error,
@@ -10,19 +10,21 @@ use std::{
 };
 use tokio_tungstenite::tungstenite::Error as TungsteniteError;
 
+/// 通用的API错误类型
 #[derive(Debug)]
-pub enum SessionError {
+pub enum ZhipuApiError {
     Decode(DecodeError),
     InvalidHeader(InvalidHeaderValue),
     Io(IoError),
     Json(JsonError),
     Realtime(RealtimeError),
+    Reqwest(ReqwestError),
     StatusCode(String),
     SystemTime(SystemTimeError),
     TungsteniteError(TungsteniteError),
 }
 
-impl Display for SessionError {
+impl Display for ZhipuApiError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "RealtimeApiError: ")?;
         match self {
@@ -31,6 +33,7 @@ impl Display for SessionError {
             Self::Io(e) => Display::fmt(e, f),
             Self::Json(e) => Display::fmt(e, f),
             Self::Realtime(e) => Display::fmt(e, f),
+            Self::Reqwest(e) => Display::fmt(e, f),
             Self::StatusCode(e) => Display::fmt(e, f),
             Self::SystemTime(e) => Display::fmt(e, f),
             Self::TungsteniteError(e) => Display::fmt(e, f),
@@ -38,46 +41,52 @@ impl Display for SessionError {
     }
 }
 
-impl Error for SessionError {}
+impl Error for ZhipuApiError {}
 
-impl From<IoError> for SessionError {
+impl From<IoError> for ZhipuApiError {
     fn from(value: IoError) -> Self {
         Self::Io(value)
     }
 }
 
-impl From<JsonError> for SessionError {
+impl From<JsonError> for ZhipuApiError {
     fn from(value: JsonError) -> Self {
         Self::Json(value)
     }
 }
 
-impl From<SystemTimeError> for SessionError {
+impl From<SystemTimeError> for ZhipuApiError {
     fn from(value: SystemTimeError) -> Self {
         Self::SystemTime(value)
     }
 }
 
-impl From<TungsteniteError> for SessionError {
+impl From<TungsteniteError> for ZhipuApiError {
     fn from(value: TungsteniteError) -> Self {
         Self::TungsteniteError(value)
     }
 }
 
-impl From<InvalidHeaderValue> for SessionError {
+impl From<InvalidHeaderValue> for ZhipuApiError {
     fn from(value: InvalidHeaderValue) -> Self {
         Self::InvalidHeader(value)
     }
 }
 
-impl From<DecodeError> for SessionError {
+impl From<DecodeError> for ZhipuApiError {
     fn from(value: DecodeError) -> Self {
         Self::Decode(value)
     }
 }
 
-impl From<RealtimeError> for SessionError {
+impl From<RealtimeError> for ZhipuApiError {
     fn from(value: RealtimeError) -> Self {
         Self::Realtime(value)
+    }
+}
+
+impl From<ReqwestError> for ZhipuApiError {
+    fn from(value: ReqwestError) -> Self {
+        Self::Reqwest(value)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 mod api_resource;
+mod error;
 mod http;
 pub mod prelude;
 mod role;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -8,12 +8,9 @@ pub use crate::api_resource::{
         Event as RealtimeEvent, EventData as RealtimeEventData,
         InputTokenDetails as RealtimeInputTokenDetails,
         OutputTokenDetails as RealtimeOutputTokenDetails, Session as RealtimeSession,
-        SessionError as RealtimeSessionError, TurnDetection as RealtimeTurnDetection,
-        Usage as RealtimeUsage, VadType as RealtimeVadType,
+        TurnDetection as RealtimeTurnDetection, Usage as RealtimeUsage, VadType as RealtimeVadType,
     },
     BigModel,
 };
-pub use crate::http::*;
-pub use crate::role::*;
+pub use crate::{error::*, http::*, role::*};
 pub use futures::StreamExt;
-pub use reqwest::Error;


### PR DESCRIPTION
统一了Error类型，在之前有个问题：
有一些Result使用了Box&lt;dyn Error&gt;，但是这个类型无法在要求Send特征的Future中跨越.await调用，例如：
```rust
tokio::spawn(async move {
    let response = post(api_url, API_KEY, request_json.to_json()).await?;

    let stream = response_context_stream(response);
    tokio::pin!(stream);
    while let Some(item) = stream.next().await {
        let item = item?;
        print!("{}", item);
    }
});
```
这会有下面的提示：
```text
= help: the trait `Send` is not implemented for `(dyn std::error::Error + 'static)`
note: future is not `Send` as this value is used across an await
   --> src\main.rs:72:46
    |
71  |         tokio::pin!(stream);
    |         ------------------- has type `impl futures_core::stream::Stream<Item = Result<String, Box<(dyn std::error::Error + 'static)>>>` which is not `Send`
72  |         while let Some(item) = stream.next().await {
    |                                              ^^^^^ await occurs here, with `mut $x` maybe used later
note: required by a bound in `tokio::spawn`
   --> D:\rust\cargo\registry\src\index.crates.io-6f17d22bba15001f\tokio-1.43.0\src\task\spawn.rs:168:21
    |
166 |     pub fn spawn<F>(future: F) -> JoinHandle<F::Output>
    |            ----- required by a bound in this function
167 |     where
168 |         F: Future + Send + 'static,
    |                     ^^^^ required by this bound in `spawn`
```
